### PR TITLE
Support namespaces in _class_name_to_table_name

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -191,7 +191,11 @@
          * For example, CarTyre would be converted to car_tyre.
          */
         protected static function _class_name_to_table_name($class_name) {
-            return strtolower(preg_replace('/(?<=[a-z])([A-Z])/', '_$1', $class_name));
+            return strtolower(preg_replace(
+                array('/\\\\/', '/(?<=[a-z])([A-Z])/', '/__/'),
+                array('_',      '_$1',                 '_'),
+                $class_name
+            ));
         }
 
         /**

--- a/test/test_php53.php
+++ b/test/test_php53.php
@@ -1,0 +1,33 @@
+<?php
+
+    namespace Tests;
+
+    use ORM, Model,DummyPDO, Tester;
+
+    /*
+     * Testing for Paris for features specifics to PHP >= 5.3
+     *
+     * We deliberately don't test the query API - that's Idiorm's job.
+     * We just test Paris-specific functionality.
+     *
+     * Checks that the generated SQL is correct
+     *
+     */
+
+    require_once dirname(__FILE__) . "/idiorm.php";
+    require_once dirname(__FILE__) . "/../paris.php";
+    require_once dirname(__FILE__) . "/test_classes.php";
+
+    // Enable logging
+    ORM::configure('logging', true);
+
+    // Set up the dummy database connection
+    $db = new DummyPDO('sqlite::memory:');
+    ORM::set_db($db);
+
+    class Simple extends Model {
+    }
+
+    Model::factory('Tests\Simple')->find_many();
+    $expected = 'SELECT * FROM `tests_simple`';
+    Tester::check_equal("Namespaced auto table name", $expected);

--- a/test/test_queries.php
+++ b/test/test_queries.php
@@ -195,5 +195,9 @@
     $expected = "SELECT `author_two`.* FROM `author_two` JOIN `wrote_the_book` ON `author_two`.`id` = `wrote_the_book`.`custom_author_id` WHERE `wrote_the_book`.`custom_book_id` = '1'";
     Tester::check_equal("has_many_through relation with custom intermediate model and key names", $expected);
 
+    if (phpversion() >= '5.3.0') {
+        include __DIR__.'/test_php53.php';
+    }
+
     Tester::report();
-?>
+


### PR DESCRIPTION
This PR correct the automatic table name when using paris with namespaces.
