### PR TITLE
Update Model->belongs_to 

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -268,7 +268,7 @@
             $associated_table_name = self::_get_table_name($associated_class_name);
             $foreign_key_name = self::_build_foreign_key_name($foreign_key_name, $associated_table_name);
             $associated_object_id = $this->$foreign_key_name;
-            return self::factory($associated_class_name)->where_id_is($associated_object_id);
+            return self::factory($associated_class_name)->find_one($associated_object_id);
         }
 
         /**


### PR DESCRIPTION
I was having problems getting Model::belongs_to working, upon digging in I saw that it was calling where_id_is which is part of ORM, and Model doesn't inherit from ORM.

I swapped the call out for Model::find_one and it worked for me.
