### PR TITLE
Change autoload option to classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
         "j4mie/idiorm": "1.2.*"
     },
     "autoload": {
-        "files": ["paris.php"]
+        "classmap": ["paris.php"]
     }
 }


### PR DESCRIPTION
Instead of requiring the file explicitly on every request the classmap option allows to load the class on-demand
