### PR TITLE
Implement PHP 5.4 JsonSerializable

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -49,7 +49,7 @@
      * directly. It is used internally by the Model base
      * class.
      */
-    class ORMWrapper extends ORM {
+    class ORMWrapper extends ORM implements JsonSerializable{
 
         /**
          * The wrapped find_one and find_many classes will
@@ -402,5 +402,10 @@
          */
         public function hydrate($data) {
             $this->orm->hydrate($data)->force_all_dirty();
+        }
+
+        //Serializes object to JSON
+        public function jsonSerialize(){
+            return $this->_data;
         }
     }


### PR DESCRIPTION
Is there any chance that Paris could implement the `JsonSerializable` [interface](http://php.net/manual/en/class.jsonserializable.php) that was introduced in PHP 5.4.0?

This would allow us to call `json_encode()` on our models, and have everything behave as expected.
