### PR TITLE
Bumps Idiorm composer requirement to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     ],
     "require": {
         "php": ">=5.2.0",
-        "j4mie/idiorm": "1.3.*"
+        "j4mie/idiorm": "1.4.*"
     },
     "autoload": {
         "classmap": ["paris.php"]


### PR DESCRIPTION
The idiorm requirement is currently set at 1.3 - with the simultaneous release of the 1.4 version of idiorm, I would suggest that this needs changing.
