### PR TITLE
$orm assignment moved into the constructor as a dependency

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -102,7 +102,7 @@
          */
         protected function _create_model_instance($orm) {
             if (! $orm instanceof ORM) {
-                return false;
+                return null;
             }
             $model = new $this->_class_name($orm);
             return $model;
@@ -178,6 +178,10 @@
          * dependency injection of the ORM instance associated with this Model instance.
          */
         public function __construct($orm) {
+            if (! $orm instanceof ORM) {
+                throw new Exception('$orm must be an instanceof Idiorm ORM!');
+            }
+
             $this->orm = $orm;
         }
 


### PR DESCRIPTION
Hello Jamie,

as a Model always need an idiorm instance to function properly, i think it could be a good idea to have a dependency in the constructor, so that you cannot instantiate a model by yourself without passing an ORM object into it.

Pleas take a look (and check) at this PR to see if it can be useful.

kind regards,
maks
