### PR TITLE
prevent infinite loop in magic __call method

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -517,6 +517,9 @@
          */
         public function __call($name, $arguments) {
             $method = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $name));
-            return call_user_func_array(array($this, $method), $arguments);
+            if(method_exists($this, $method)) {
+               return call_user_func_array(array($this, $method), $arguments);
+            }
+            trigger_error(sprintf('Call to undefined method %s::%s()', get_called_class(), $name), E_USER_ERROR);
         }
     }


### PR DESCRIPTION
else any call of an undefined method where also underscored version is not found will cause an infinit loop.
