### PR TITLE
Allows static calling of Model subclasses, ignoring namespace info during table name generation.

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -37,8 +37,19 @@ in a similar way. For example ``\Models\CarTyre`` would be converted to
 ``models_car_tyre``. Note here that backslashes are replaced with underscores
 in addition to the *CapWords* replacement discussed in the previous paragraph.
 
-To override this default behaviour, add a **public static** property to
-your class called ``$_table``:
+To disregard namespace information when calculating the table name, set a
+**public static** property named ``$_table_use_short_name`` on your class.
+This would result in ``\Models\CarTyre`` being converted to ``car_tyre``.
+
+.. code-block:: php
+
+    <?php
+    class User extends Model {
+        public static $_table_use_short_name = true;
+    }
+
+To override the default naming behaviour and directly specify a table name,
+add a **public static** property to your class called ``$_table``:
 
 .. code-block:: php
 

--- a/paris.php
+++ b/paris.php
@@ -190,12 +190,26 @@
          * Static method to get a table name given a class name.
          * If the supplied class has a public static property
          * named $_table, the value of this property will be
-         * returned. If not, the class name will be converted using
+         * returned.
+         *
+         * If not, the class name will be converted using
          * the _class_name_to_table_name method method.
+         *
+         * If public static property $_table_use_short_name == true
+         * then $class_name passed to _class_name_to_table_name is
+         * stripped of namespace information.
+         *
          */
         protected static function _get_table_name($class_name) {
             $specified_table_name = self::_get_static_property($class_name, '_table');
             if (is_null($specified_table_name)) {
+                $use_short_class_name =
+                    self::_get_static_property($class_name, '_table_use_short_name');
+
+                if ($use_short_class_name) {
+                    $class_name = end(explode('\\', $class_name));
+                }
+
                 return self::_class_name_to_table_name($class_name);
             }
             return $specified_table_name;

--- a/test/ParisTest.php
+++ b/test/ParisTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use test\name\space\ModelWithCustomNamespace;
+use test\name\space\ModelWithCustomNamespaceToIgnore;
+
 class ParisTest extends PHPUnit_Framework_TestCase {
 
     const ALTERNATE = 'alternate';
@@ -26,6 +29,18 @@ class ParisTest extends PHPUnit_Framework_TestCase {
     public function testComplexModelClassName() {
         Model::factory('ComplexModelClassName')->find_many();
         $expected = 'SELECT * FROM `complex_model_class_name`';
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testModelClassNameWithNamespace() {
+        ModelWithCustomNamespace::find_many();
+        $expected = 'SELECT * FROM `test_name_space_model_with_custom_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
+    public function testModelClassNameWithNamespaceIgnored() {
+        ModelWithCustomNamespaceToIgnore::find_many();
+        $expected = 'SELECT * FROM `model_with_custom_namespace_to_ignore`';
         $this->assertEquals($expected, ORM::get_last_query());
     }
 

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,168 +1,275 @@
 <?php
 
-require_once dirname(__FILE__) . '/idiorm.php';
-require_once dirname(__FILE__) . "/../paris.php";
-
-/**
- *
- * Mock version of the PDOStatement class.
- *
- */
-class MockPDOStatement extends PDOStatement {
-
-   private $current_row = 0;
-   
-   public function __construct() {}
-   public function execute($params) {}
-   
-   /**
-    * Return some dummy data
-    */
-   public function fetch($fetch_style=PDO::FETCH_BOTH, $cursor_orientation=PDO::FETCH_ORI_NEXT, $cursor_offset=0) {
-       if ($this->current_row == 5) {
-           return false;
-       } else {
-           return array('name' => 'Fred', 'age' => 10, 'id' => ++$this->current_row);
-       }
-   }
-}
-
-/**
- *
- * Mock database class implementing a subset
- * of the PDO API.
- *
- */
-class MockPDO extends PDO {
-
-   /**
-    * Return a dummy PDO statement
-    */
-   public function prepare($statement, $driver_options=array()) {
-       $this->last_query = new MockPDOStatement($statement);
-       return $this->last_query;
-   }
-}
-
-/**
- * Another mock PDOStatement class, used for testing multiple connections
- */
-class MockDifferentPDOStatement extends MockPDOStatement {}
-
-/**
- * A different mock database class, for testing multiple connections
- * Mock database class implementing a subset of the PDO API.
- */
-class MockDifferentPDO extends MockPDO {
+namespace {
+    require_once dirname(__FILE__) . '/idiorm.php';
+    require_once dirname(__FILE__) . "/../paris.php";
 
     /**
-     * Return a dummy PDO statement
+     *
+     * Mock version of the PDOStatement class.
+     *
      */
-    public function prepare($statement, $driver_options = array()) {
-        $this->last_query = new MockDifferentPDOStatement($statement);
-        return $this->last_query;
+    class MockPDOStatement extends PDOStatement
+    {
+
+        private $current_row = 0;
+
+        public function __construct()
+        {
+        }
+
+        public function execute($params)
+        {
+        }
+
+        /**
+         * Return some dummy data
+         */
+        public function fetch(
+            $fetch_style = PDO::FETCH_BOTH, $cursor_orientation = PDO::FETCH_ORI_NEXT, $cursor_offset = 0)
+        {
+            if ($this->current_row == 5) {
+                return false;
+            } else {
+                return array('name' => 'Fred', 'age' => 10, 'id' => ++$this->current_row);
+            }
+        }
+    }
+
+    /**
+     *
+     * Mock database class implementing a subset
+     * of the PDO API.
+     *
+     */
+    class MockPDO extends PDO
+    {
+
+        /**
+         * Return a dummy PDO statement
+         */
+        public function prepare($statement, $driver_options = array())
+        {
+            $this->last_query = new MockPDOStatement($statement);
+            return $this->last_query;
+        }
+    }
+
+    /**
+     * Another mock PDOStatement class, used for testing multiple connections
+     */
+    class MockDifferentPDOStatement extends MockPDOStatement
+    {
+    }
+
+    /**
+     * A different mock database class, for testing multiple connections
+     * Mock database class implementing a subset of the PDO API.
+     */
+    class MockDifferentPDO extends MockPDO
+    {
+
+        /**
+         * Return a dummy PDO statement
+         */
+        public function prepare($statement, $driver_options = array())
+        {
+            $this->last_query = new MockDifferentPDOStatement($statement);
+            return $this->last_query;
+        }
+    }
+
+    /**
+     * Models for use during testing
+     */
+    class Simple extends Model
+    {
+    }
+
+    class ComplexModelClassName extends Model
+    {
+    }
+
+    class ModelWithCustomTable extends Model
+    {
+        public static $_table = 'custom_table';
+    }
+
+    class ModelWithCustomTableAndCustomIdColumn extends Model
+    {
+        public static $_table = 'custom_table';
+        public static $_id_column = 'custom_id_column';
     }
 }
 
-/**
- * Models for use during testing
- */
-class Simple extends Model { }
-class ComplexModelClassName extends Model { }
-class ModelWithCustomTable extends Model {
-    public static $_table = 'custom_table';
-}
-class ModelWithCustomTableAndCustomIdColumn extends Model {
-    public static $_table = 'custom_table';
-    public static $_id_column = 'custom_id_column';
-}
-class ModelWithFilters extends Model {
-    public static function name_is_fred($orm) {
-        return $orm->where('name', 'Fred');
+    namespace test\name\space {
+        use Model;
+        class ModelWithCustomNamespace extends Model
+        {
+        }
+        class ModelWithCustomNamespaceToIgnore extends Model
+        {
+            public static $_table_use_short_name = true;
+        }
     }
-    public static function name_is($orm, $name) {
-        return $orm->where('name', $name);
-    }
-}
-class ModelWithCustomConnection extends Model {
-    const ALTERNATE = 'alternate';
-    public static $_connection_name = self::ALTERNATE;
-}
 
-class Profile extends Model {
-    public function user() {
-        return $this->belongs_to('User');
+namespace {
+    class ModelWithFilters extends Model
+    {
+        public static function name_is_fred($orm)
+        {
+            return $orm->where('name', 'Fred');
+        }
+
+        public static function name_is($orm, $name)
+        {
+            return $orm->where('name', $name);
+        }
     }
-} 
-class User extends Model {
-    public function profile() {
-        return $this->has_one('Profile');
+
+    class ModelWithCustomConnection extends Model
+    {
+        const ALTERNATE = 'alternate';
+        public static $_connection_name = self::ALTERNATE;
+    }
+
+    class Profile extends Model
+    {
+        public function user()
+        {
+            return $this->belongs_to('User');
+        }
+    }
+
+    class User extends Model
+    {
+        public function profile()
+        {
+            return $this->has_one('Profile');
+        }
+    }
+
+    class UserTwo extends Model
+    {
+        public function profile()
+        {
+            return $this->has_one('Profile', 'my_custom_fk_column');
+        }
+    }
+
+    class UserFive extends Model
+    {
+        public function profile()
+        {
+            return $this->has_one('Profile', 'my_custom_fk_column', 'name');
+        }
+    }
+
+    class ProfileTwo extends Model
+    {
+        public function user()
+        {
+            return $this->belongs_to('User', 'custom_user_fk_column');
+        }
+    }
+
+    class ProfileThree extends Model
+    {
+        public function user()
+        {
+            return $this->belongs_to('User', 'custom_user_fk_column', 'name');
+        }
+    }
+
+    class Post extends Model
+    {
+    }
+
+    class UserThree extends Model
+    {
+        public function posts()
+        {
+            return $this->has_many('Post');
+        }
+    }
+
+    class UserFour extends Model
+    {
+        public function posts()
+        {
+            return $this->has_many('Post', 'my_custom_fk_column');
+        }
+    }
+
+    class UserSix extends Model
+    {
+        public function posts()
+        {
+            return $this->has_many('Post', 'my_custom_fk_column', 'name');
+        }
+    }
+
+    class Author extends Model
+    {
+    }
+
+    class AuthorBook extends Model
+    {
+    }
+
+    class Book extends Model
+    {
+        public function authors()
+        {
+            return $this->has_many_through('Author');
+        }
+    }
+
+    class BookTwo extends Model
+    {
+        public function authors()
+        {
+            return $this->has_many_through('Author', 'AuthorBook', 'custom_book_id', 'custom_author_id');
+        }
+    }
+
+    class BookThree extends Model
+    {
+        public function authors()
+        {
+            return $this->has_many_through(
+                'Author', 'AuthorBook', 'custom_book_id', 'custom_author_id', 'custom_book_id_in_book_table',
+                'custom_author_id_in_author_table'
+            );
+        }
+    }
+
+    class BookFour extends Model
+    {
+        public function authors()
+        {
+            return $this->has_many_through(
+                'Author', 'AuthorBook', 'custom_book_id', 'custom_author_id', null, 'custom_author_id_in_author_table'
+            );
+        }
+    }
+
+    class BookFive extends Model
+    {
+        public function authors()
+        {
+            return $this->has_many_through(
+                'Author', 'AuthorBook', 'custom_book_id', 'custom_author_id', 'custom_book_id_in_book_table'
+            );
+        }
+    }
+
+    class MockPrefix_Simple extends Model
+    {
+    }
+
+    class MockPrefix_TableSpecified extends Model
+    {
+        public static $_table = 'simple';
     }
 }
-class UserTwo extends Model {
-    public function profile() {
-        return $this->has_one('Profile', 'my_custom_fk_column');
-    }
-}
-class UserFive extends Model {
-    public function profile() {
-        return $this->has_one('Profile', 'my_custom_fk_column', 'name');
-    }
-}
-class ProfileTwo extends Model {
-    public function user() {
-        return $this->belongs_to('User', 'custom_user_fk_column');
-    }
-}
-class ProfileThree extends Model {
-    public function user() {
-        return $this->belongs_to('User', 'custom_user_fk_column', 'name');
-    }
-}
-class Post extends Model { }
-class UserThree extends Model {
-    public function posts() {
-        return $this->has_many('Post');
-    }
-}
-class UserFour extends Model {
-    public function posts() {
-        return $this->has_many('Post', 'my_custom_fk_column');
-    }
-}
-class UserSix extends Model {
-    public function posts() {
-        return $this->has_many('Post', 'my_custom_fk_column', 'name');
-    }
-}
-class Author extends Model { }
-class AuthorBook extends Model { }
-class Book extends Model {
-    public function authors() {
-        return $this->has_many_through('Author');
-    }
-}
-class BookTwo extends Model {
-    public function authors() {
-        return $this->has_many_through('Author', 'AuthorBook', 'custom_book_id', 'custom_author_id');
-    }
-}
-class BookThree extends Model {
-    public function authors() {
-        return $this->has_many_through('Author', 'AuthorBook', 'custom_book_id', 'custom_author_id', 'custom_book_id_in_book_table', 'custom_author_id_in_author_table');
-    }
-}
-class BookFour extends Model {
-    public function authors() {
-        return $this->has_many_through('Author', 'AuthorBook', 'custom_book_id', 'custom_author_id', null, 'custom_author_id_in_author_table');
-    }
-}
-class BookFive extends Model {
-    public function authors() {
-        return $this->has_many_through('Author', 'AuthorBook', 'custom_book_id', 'custom_author_id', 'custom_book_id_in_book_table');
-    }
-}
-class MockPrefix_Simple extends Model { } 
-class MockPrefix_TableSpecified extends Model {
-    public static $_table = 'simple';
-} 


### PR DESCRIPTION
Model class static property $_table_use_short_name = true allows static calling of the model subclass whilst avoiding the inclusion of namespace information in the auto generated table name.

Resolves issue #88.

Please note that the large number of changes to bootstrap.php is due to indentation changes after wrapping the code with a blank namespace. This was necessary because the new tests required a namespace and the rest wouldn't run without the changes.

The new code is at test/bootstrap.php:110
