### PR TITLE
Resolves issue #88. Allows static calling of Model subclasses, ignoring namespace info during table name generation.

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -37,8 +37,19 @@ in a similar way. For example ``\Models\CarTyre`` would be converted to
 ``models_car_tyre``. Note here that backslashes are replaced with underscores
 in addition to the *CapWords* replacement discussed in the previous paragraph.
 
-To override this default behaviour, add a **public static** property to
-your class called ``$_table``:
+To disregard namespace information when calculating the table name, set a
+**public static** property named ``$_table_use_short_name`` on your class.
+This would result in ``\Models\CarTyre`` being converted to ``car_tyre``.
+
+.. code-block:: php
+
+    <?php
+    class User extends Model {
+        public static $_table_use_short_name = true;
+    }
+
+To override the default naming behaviour and directly specify a table name,
+add a **public static** property to your class called ``$_table``:
 
 .. code-block:: php
 

--- a/paris.php
+++ b/paris.php
@@ -190,11 +190,26 @@
          * Static method to get a table name given a class name.
          * If the supplied class has a public static property
          * named $_table, the value of this property will be
-         * returned. If not, the class name will be converted using
+         * returned.
+         *
+         * If not, the class name will be converted using
          * the _class_name_to_table_name method method.
+         *
+         * If public static property $_table_use_short_name == true
+         * then $class_name passed to _class_name_to_table_name is
+         * stripped of namespace information.
+         *
          */
         protected static function _get_table_name($class_name) {
             $specified_table_name = self::_get_static_property($class_name, '_table');
+            $use_short_class_name =
+                self::_get_static_property($class_name, '_table_use_short_name');
+
+            if ($use_short_class_name) {
+                $exploded_class_name = explode('\\', $class_name);
+                $class_name = end($exploded_class_name);
+            }
+
             if (is_null($specified_table_name)) {
                 return self::_class_name_to_table_name($class_name);
             }

--- a/test/ParisTest53.php
+++ b/test/ParisTest53.php
@@ -25,6 +25,12 @@ class ParisTest53 extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, ORM::get_last_query());
     }
 
+    public function testIgnoredNamespaceTableName() {
+        IgnoreNamespace::find_many();
+        $expected = 'SELECT * FROM `ignore_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
+    }
+
     public function testModelWithCustomTable() {
         Model::factory('ModelWithCustomTable')->find_many();
         $expected = 'SELECT * FROM `custom_table`';
@@ -42,4 +48,7 @@ class ParisTest53 extends PHPUnit_Framework_TestCase {
 class Simple extends Model { }
 class ModelWithCustomTable extends Model {
     public static $_table = 'custom_table';
+}
+class IgnoreNamespace extends Model {
+    public static $_table_use_short_name = true;
 }


### PR DESCRIPTION
`Model` class `static property $_table_use_short_name = true` allows static calling of the model subclass whilst avoiding the inclusion of namespace information in the auto generated table name.
