### PR TITLE
Fixes incorrect parameter names in docs

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -422,7 +422,7 @@
 
         /**
          * Setter method, allows $model->set('property', 'value') access to data.
-         * @param string|array $key
+         * @param string|array $property
          * @param string|null $value
          */
         public function set($property, $value = null) {
@@ -431,7 +431,7 @@
 
         /**
          * Setter method, allows $model->set_expr('property', 'value') access to data.
-         * @param string|array $key
+         * @param string|array $property
          * @param string|null $value
          */
         public function set_expr($property, $value = null) {


### PR DESCRIPTION
Changes `$key` to `$property` in docs to reflect reality
