### PR TITLE
Adds global configuration option Model::$short_table_names to allow namespace information to be disregarded when generating table names

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,6 +62,30 @@ Here is a namespaced example to make it clearer:
     individual model classes. As documented in the :doc:`Models` section of
     the documentation.
 
+Model prefixing
+~~~~~~~~~~~~~~~
+
+Setting: ``Model::$short_table_names``
+
+Set as ``true`` to disregard namespace information when computing table names
+from class names.
+
+By default the class ``\Models\CarTyre`` expects the table name ``models_car_tyre``.
+With ``Model::$short_table_names = true`` the class ``\Models\CarTyre`` expects the
+table name ``car_tyre``.
+
+.. code-block:: php
+
+    <?php
+
+    Model::$short_table_names = true;
+    Model::factory('CarTyre')->find_many(); // SQL executed: SELECT * FROM `car_tyre`
+
+    namespace Models {
+        class CarTyre extends Model {
+
+        }
+    }
 
 Further Configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -37,9 +37,14 @@ in a similar way. For example ``\Models\CarTyre`` would be converted to
 ``models_car_tyre``. Note here that backslashes are replaced with underscores
 in addition to the *CapWords* replacement discussed in the previous paragraph.
 
-To disregard namespace information when calculating the table name, set a
-**public static** property named ``$_table_use_short_name`` on your class.
-This would result in ``\Models\CarTyre`` being converted to ``car_tyre``.
+To disregard namespace information when calculating the table name, set
+``Model::$short_table_names = true;``. Optionally this may be set or overridden at
+class level with the **public static** property ``$_table_use_short_name``. The
+
+``$_table_use_short_name`` takes precedence over ``Model::$short_table_names``
+unless ``$_table_use_short_name`` is ``null`` (default).
+
+Either setting results in ``\Models\CarTyre`` being converted to ``car_tyre``.
 
 .. code-block:: php
 

--- a/paris.php
+++ b/paris.php
@@ -191,6 +191,17 @@
         public static $auto_prefix_models = null;
 
         /**
+         * Set true to to ignore namespace information when computing table names
+         * from class names.
+         *
+         * @example Model::$short_table_names = true;
+         * @example Model::$short_table_names = false; // default
+         *
+         * @var bool $short_table_names
+         */
+        public static $short_table_names = false;
+
+        /**
          * The ORM instance used by this model 
          * instance to communicate with the database.
          *
@@ -225,17 +236,18 @@
          * If not, the class name will be converted using
          * the _class_name_to_table_name method method.
          *
-         * If public static property $_table_use_short_name == true
-         * then $class_name passed to _class_name_to_table_name is
-         * stripped of namespace information.
+         * If Model::$short_table_names == true or public static
+         * property $_table_use_short_name == true then $class_name passed
+         * to _class_name_to_table_name is stripped of namespace information.
          *
          * @param  string $class_name
-         * @return string
+         *
+*@return string
          */
         protected static function _get_table_name($class_name) {
             $specified_table_name = self::_get_static_property($class_name, '_table');
-            $use_short_class_name =
-                self::_get_static_property($class_name, '_table_use_short_name');
+
+            $use_short_class_name = self::_use_short_table_name($class_name);
 
             if ($use_short_class_name) {
                 $exploded_class_name = explode('\\', $class_name);
@@ -246,6 +258,20 @@
                 return self::_class_name_to_table_name($class_name);
             }
             return $specified_table_name;
+        }
+
+        /**
+         * Should short table names, disregarding class namespaces, be computed?
+         *
+         * $class_property overrides $global_option, unless $class_property is null
+         *
+         * @param string $class_name
+         * @return bool
+         */
+        protected static function _use_short_table_name($class_name) {
+            $global_option = self::$short_table_names;
+            $class_property = self::_get_static_property($class_name, '_table_use_short_name');
+            return is_null($class_property) ? $global_option : $class_property;
         }
 
         /**

--- a/test/ParisTest53.php
+++ b/test/ParisTest53.php
@@ -36,6 +36,11 @@ class ParisTest53 extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expected, ORM::get_last_query());
 
         Model::$short_table_names = false;
+        MustUseGlobalNamespaceConfig::find_many();
+        $expected = 'SELECT * FROM `paris_tests_must_use_global_namespace_config`';
+        $this->assertEquals($expected, ORM::get_last_query());
+
+        Model::$short_table_names = false;
         MustNotIgnoreNamespace::find_many();
         $expected = 'SELECT * FROM `paris_tests_must_not_ignore_namespace`';
         $this->assertEquals($expected, ORM::get_last_query());
@@ -49,6 +54,11 @@ class ParisTest53 extends PHPUnit_Framework_TestCase {
         Model::$short_table_names = true;
         MustIgnoreNamespace::find_many();
         $expected = 'SELECT * FROM `must_ignore_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
+
+        Model::$short_table_names = true;
+        MustUseGlobalNamespaceConfig::find_many();
+        $expected = 'SELECT * FROM `must_use_global_namespace_config`';
         $this->assertEquals($expected, ORM::get_last_query());
 
         Model::$short_table_names = false;
@@ -80,4 +90,7 @@ class MustIgnoreNamespace extends Model {
 }
 class MustNotIgnoreNamespace extends Model {
     public static $_table_use_short_name = false;
+}
+class MustUseGlobalNamespaceConfig extends Model {
+    public static $_table_use_short_name = null;
 }

--- a/test/ParisTest53.php
+++ b/test/ParisTest53.php
@@ -19,15 +19,41 @@ class ParisTest53 extends PHPUnit_Framework_TestCase {
         ORM::set_db(null);
     }
 
+
+
     public function testNamespacedTableName() {
         Model::factory('Paris\Tests\Simple')->find_many();
         $expected = 'SELECT * FROM `paris_tests_simple`';
         $this->assertEquals($expected, ORM::get_last_query());
+
+        MustNotIgnoreNamespace::find_many();
+        $expected = 'SELECT * FROM `paris_tests_must_not_ignore_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
+
+        Model::$short_table_names = true;
+        MustNotIgnoreNamespace::find_many();
+        $expected = 'SELECT * FROM `paris_tests_must_not_ignore_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
+
+        Model::$short_table_names = false;
+        MustNotIgnoreNamespace::find_many();
+        $expected = 'SELECT * FROM `paris_tests_must_not_ignore_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
     }
 
     public function testIgnoredNamespaceTableName() {
-        IgnoreNamespace::find_many();
-        $expected = 'SELECT * FROM `ignore_namespace`';
+        MustIgnoreNamespace::find_many();
+        $expected = 'SELECT * FROM `must_ignore_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
+
+        Model::$short_table_names = true;
+        MustIgnoreNamespace::find_many();
+        $expected = 'SELECT * FROM `must_ignore_namespace`';
+        $this->assertEquals($expected, ORM::get_last_query());
+
+        Model::$short_table_names = false;
+        MustIgnoreNamespace::find_many();
+        $expected = 'SELECT * FROM `must_ignore_namespace`';
         $this->assertEquals($expected, ORM::get_last_query());
     }
 
@@ -49,6 +75,9 @@ class Simple extends Model { }
 class ModelWithCustomTable extends Model {
     public static $_table = 'custom_table';
 }
-class IgnoreNamespace extends Model {
+class MustIgnoreNamespace extends Model {
     public static $_table_use_short_name = true;
+}
+class MustNotIgnoreNamespace extends Model {
+    public static $_table_use_short_name = false;
 }


### PR DESCRIPTION
As discussed in PR #90.
