### PR TITLE
Documents conflict between use of static Model calling (not using the factory method) and Model::$auto_prefix_models property

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -56,11 +56,15 @@ Here is a namespaced example to make it clearer:
     Model::factory('Simple')->find_many(); // SQL executed: SELECT * FROM `tests_simple`
     Model::factory('SimpleUser')->find_many(); // SQL executed: SELECT * FROM `tests_simple_user`
 
+Model prefixes are only compatible with the ``Model::factory()`` methods described above.
+Where the shorter ``SimpleUser::find_many()`` style syntax is used, the addition of a
+Model prefix will cause ``Class not found`` errors.
+
 .. note::
 
-    It is possible to define the table name by setting ``$_table`` in your
-    individual model classes. As documented in the :doc:`Models` section of
-    the documentation.
+    Model class property ``$_table`` sets an explicit table name, ignoring the
+    ``$auto_prefix_models`` property in your individual model classes. See documentation in
+    the :doc:`Models` section of the documentation.
 
 
 Further Configuration


### PR DESCRIPTION
In regard to clarifying the situation raised in issue #101.
