### PR TITLE
Added a missing '@' and docs for magic methods

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,6 +74,10 @@ foreach ($tweets as $tweet) {
 Changelog
 ---------
 
+#### 1.5.6 - released 2014-10-01
+
+* Added @method tags for magic methods [[stellis](https://github.com/stellis)]
+
 #### 1.5.5 - released 2014-10-01
 
 * Added missing '@' for a @return tag for create() method [[stellis](https://github.com/stellis)]

--- a/README.markdown
+++ b/README.markdown
@@ -74,6 +74,10 @@ foreach ($tweets as $tweet) {
 Changelog
 ---------
 
+#### 1.5.5 - released 2014-10-01
+
+* Added missing '@' for a @return tag for create() method [[stellis](https://github.com/stellis)]
+
 #### 1.5.4 - released 2014-09-23
 
 * Corrects return value in docblock for 2 Model functions [[michaelward82](https://github.com/michaelward82)] - [issue #99](https://github.com/j4mie/paris/pull/99)

--- a/paris.php
+++ b/paris.php
@@ -155,7 +155,7 @@
          * empty instance of the class associated with
          * this wrapper instead of the raw ORM class.
          *
-         *  return ORMWrapper|bool
+         * @return ORMWrapper|bool
          */
         public function create($data=null) {
             return $this->_create_model_instance(parent::create($data));

--- a/paris.php
+++ b/paris.php
@@ -48,6 +48,10 @@
      * You shouldn't need to interact with this class
      * directly. It is used internally by the Model base
      * class.
+     * @method void setClassName($class_name)
+     * @method static \ORMWrapper forTable($table_name, $connection_name = parent::DEFAULT_CONNECTION)
+     * @method \Model findOne($id=null)
+     * @method Array findMany()
      */
     class ORMWrapper extends ORM {
 
@@ -169,6 +173,11 @@
      * class Widget extends Model {
      * }
      *
+     * @method void setOrm($orm)
+     * @method $this setExpr($property, $value = null)
+     * @method bool isDirty($property)
+     * @method bool isNew()
+     * @method Array asArray()
      */
     class Model {
 

--- a/paris.php
+++ b/paris.php
@@ -48,6 +48,12 @@
      * You shouldn't need to interact with this class
      * directly. It is used internally by the Model base
      * class.
+     *
+     *
+     * The methods documented below are magic methods that conform to PSR-1.
+     * This documentation exposes these methods to doc generators and IDEs.
+     * @see http://www.php-fig.org/psr/psr-1/
+     *
      * @method void setClassName($class_name)
      * @method static \ORMWrapper forTable($table_name, $connection_name = parent::DEFAULT_CONNECTION)
      * @method \Model findOne($id=null)
@@ -172,6 +178,11 @@
      *
      * class Widget extends Model {
      * }
+     *
+     *
+     * The methods documented below are magic methods that conform to PSR-1.
+     * This documentation exposes these methods to doc generators and IDEs.
+     * @see http://www.php-fig.org/psr/psr-1/
      *
      * @method void setOrm($orm)
      * @method $this setExpr($property, $value = null)


### PR DESCRIPTION
Provides basic support for code completion in IDEs (tested in phpStorm) for the magic methods that were added for PSR-1 compatibility. See: http://stackoverflow.com/a/15634488
