### PR TITLE
[Bug] Replace `self::_get_table_name` with `static::_get_table_name`

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -313,7 +313,7 @@
          */
         public static function factory($class_name, $connection_name = null) {
             $class_name = self::$auto_prefix_models . $class_name;
-            $table_name = self::_get_table_name($class_name);
+            $table_name = static::_get_table_name($class_name);
 
             if ($connection_name == null) {
                $connection_name = self::_get_static_property(
@@ -341,7 +341,7 @@
          * @return ORMWrapper
          */
         protected function _has_one_or_many($associated_class_name, $foreign_key_name=null, $foreign_key_name_in_current_models_table=null, $connection_name=null) {
-            $base_table_name = self::_get_table_name(get_class($this));
+            $base_table_name = static::_get_table_name(get_class($this));
             $foreign_key_name = self::_build_foreign_key_name($foreign_key_name, $base_table_name);
             
             $where_value = ''; //Value of foreign_table.{$foreign_key_name} we're 
@@ -400,7 +400,7 @@
          * @return $this|null
          */
         protected function belongs_to($associated_class_name, $foreign_key_name=null, $foreign_key_name_in_associated_models_table=null, $connection_name=null) {
-            $associated_table_name = self::_get_table_name(self::$auto_prefix_models . $associated_class_name);
+            $associated_table_name = static::_get_table_name(self::$auto_prefix_models . $associated_class_name);
             $foreign_key_name = self::_build_foreign_key_name($foreign_key_name, $associated_table_name);
             $associated_object_id = $this->$foreign_key_name;
             
@@ -450,9 +450,9 @@
             }
 
             // Get table names for each class
-            $base_table_name = self::_get_table_name($base_class_name);
-            $associated_table_name = self::_get_table_name(self::$auto_prefix_models . $associated_class_name);
-            $join_table_name = self::_get_table_name(self::$auto_prefix_models . $join_class_name);
+            $base_table_name = static::_get_table_name($base_class_name);
+            $associated_table_name = static::_get_table_name(self::$auto_prefix_models . $associated_class_name);
+            $join_table_name = static::_get_table_name(self::$auto_prefix_models . $join_class_name);
 
             // Get ID column names
             $base_table_id_column = (is_null($key_in_base_table)) ?


### PR DESCRIPTION
Original method Model::_get_table_name is made protected to make it possible to override it.

Let's say I have subclass Db, which extends Model to override `Model::_get_table_name` method:

```
class Db extends \Model
{
    protected static function _get_table_name($class_name)
    {
       // some magic here
    }
}
```

Method is overriden, but not working, because it's called with `self::_get_table_name` in `paris.php` file.

If replace calls with `static::_get_table_name`, it may call method, overriden in child classes.

The reason is PHP architecture, more info about: http://php.net/manual/en/language.oop5.late-static-bindings.php

P.S. This change requires up php version to php 5.3