### PR TITLE
[FIX][PHP 8.1] replace get_class_vars method

### DIFF
--- a/paris.php
+++ b/paris.php
@@ -243,8 +243,8 @@
             if (!class_exists($class_name) || !property_exists($class_name, $property)) {
                 return $default;
             }
-            $properties = get_class_vars($class_name);
-            return $properties[$property];
+
+            return $class_name::$$property;
         }
 
         /**


### PR DESCRIPTION
Hello :)

 using the version php 8.1+, I am getting some strange behaviours with `get_class_vars`, and if you check on this [php issue](https://github.com/php/php-src/issues/13835), you gonna see that contains some unexpected changes.

maybe we could replace this method for get it dynamically, what do you think?  